### PR TITLE
Update ruby-maven dependency

### DIFF
--- a/jbundler.gemspec
+++ b/jbundler.gemspec
@@ -20,7 +20,7 @@ END
   s.files += Dir['Gemfile*']
   s.test_files += Dir['spec/**/*_spec.rb']
 
-  s.add_runtime_dependency "ruby-maven", "= 3.0.4.0.29.0"
+  s.add_runtime_dependency "ruby-maven", "= 3.0.4.1"
   s.add_development_dependency "rake", "0.9.2.2"
   s.add_development_dependency "thor", "< 0.16.0", "> 0.14.0"
 


### PR DESCRIPTION
I'm using jbundler and another gem that requires a more updated version of thor itself and the ruby-maven gem that jbundler depends on is a little behind. Looking at ruby-maven I noticed a more recent tag 3.0.4.1 that has a more favorable thor dependency. So I updated the ruby-maven dependency in jbundler to use 3.0.4.1.
