### PR TITLE
Use JBUNDLE_CLASSPATH_FILE to load from a different classpath file.

### DIFF
--- a/lib/jbundler/config.rb
+++ b/lib/jbundler/config.rb
@@ -79,7 +79,7 @@ module JBundler
     end
 
     def classpath_file
-      '.jbundler/classpath.rb'
+      jbundler_env('JBUNDLE_CLASSPATH_FILE') || '.jbundler/classpath.rb'
     end
 
     def local_repository


### PR DESCRIPTION
I'd like to be able to provide an alternate classpath.rb from an IntelliJ plugin I'm writing. (It'll automatically build maven dependencies and link to the locally-built classes.)

Thanks for JBundler, it's awesome!
