### PR TITLE
Don't try to load config from home directory if HOME isn't set

### DIFF
--- a/lib/jbundler/config.rb
+++ b/lib/jbundler/config.rb
@@ -31,8 +31,12 @@ module JBundler
     attr_accessor :verbose, :local_repository, :jarfile, :gemfile, :skip, :settings, :offline, :work_dir, :vendor_dir, :basedir
 
     def initialize
-      homefile = File.join(ENV['HOME'], RC_FILE)
-      home_config = YAML.load_file(homefile) if File.exists?(homefile)
+      if ENV.has_key? 'HOME'
+        homefile = File.join(ENV['HOME'], RC_FILE)
+        home_config = YAML.load_file(homefile) if File.exists?(homefile)
+      else
+        home_config = nil
+      end
       @config = (home_config || {})
       @basedir = find_basedir( File.expand_path( '.' ) )
       @basedir ||= File.expand_path( '.' )


### PR DESCRIPTION
It's possible the HOME environment variable may not be set. jbundler shouldn't crash if it isn't.
