### PR TITLE
pass local repository configuration to ruby-maven

### DIFF
--- a/lib/jbundler/configurator.rb
+++ b/lib/jbundler/configurator.rb
@@ -7,7 +7,7 @@ module JBundler
     def initialize( config )
       @config = config
     end
-    
+
     def configure( maven )
       maven.property( 'jbundler.basedir', @config.basedir )
       maven.property( 'jbundler.jarfile', @config.jarfile )
@@ -15,6 +15,7 @@ module JBundler
       maven.property( 'jbundler.workdir', work_dir )
       maven.property( 'jbundler.groups', @groups )
       maven.property( 'jbundler.bootstrap', @bootstrap )
+      maven.property( 'maven.repo.local', @config.local_repository )
     end
 
     def work_dir


### PR DESCRIPTION
This change fixes this use case:

`JARS_HOME=/tmp jruby -S bundle exec jbundle install`
