### PR TITLE
Fix error about missing jar_installer on jbundle install

### DIFF
--- a/lib/jbundler/lock_down.rb
+++ b/lib/jbundler/lock_down.rb
@@ -7,7 +7,7 @@ require 'maven/tools/gemspec_dependencies'
 require 'maven/tools/jarfile'
 require 'maven/ruby/maven'
 require 'fileutils'
-require 'jar_installer'
+require 'jars/installer'
 
 module JBundler
   class LockDown


### PR DESCRIPTION
When running `jruby -S jbundle install`  after updating to 10.0.1.0 I'm getting the following error:

```
LoadError: no such file to load -- jar_installer
  require at org/jruby/RubyKernel.java:1183
  require at /home/katafrakt/.local/share/mise/installs/ruby/jruby-10.0.1.0/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:136
   <main> at /home/katafrakt/.local/share/mise/installs/ruby/jruby-10.0.1.0/lib/ruby/gems/shared/gems/jbundler-0.9.5/lib/jbundler/lock_down.rb:10
  require at org/jruby/RubyKernel.java:1183
  require at /home/katafrakt/.local/share/mise/installs/ruby/jruby-10.0.1.0/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:136
   <main> at /home/katafrakt/.local/share/mise/installs/ruby/jruby-10.0.1.0/lib/ruby/gems/shared/gems/jbundler-0.9.5/lib/jbundler/cli.rb:24
  require at org/jruby/RubyKernel.java:1183
  require at /home/katafrakt/.local/share/mise/installs/ruby/jruby-10.0.1.0/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:136
   <main> at /home/katafrakt/.local/share/mise/installs/ruby/jruby-10.0.1.0/lib/ruby/gems/shared/gems/jbundler-0.9.5/bin/jbundle:46
     load at org/jruby/RubyKernel.java:1212
   <main> at /home/katafrakt/.local/share/mise/installs/ruby/jruby-10.0.1.0/bin/jbundle:25
```

Guessing by 5a1b1511d880f3514c61308fe895a0b68319a917, I assumed that a similar change should be made in `lock_down.rb` and indeed the command runs succesfully after this change.