### PR TITLE
fix: allow use with JRuby 10.1 / Bundler 4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [jruby-9.4, jruby-10.0]
+        ruby-version: [jruby-9.4, jruby-10.0, jruby-10.1]
 
     steps:
       - uses: actions/checkout@v5
@@ -20,5 +20,5 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
-      - run: bundle
+      - run: bundle install
       - run: bundle exec rake specs

--- a/jbundler.gemspec
+++ b/jbundler.gemspec
@@ -29,7 +29,7 @@ END
 
   s.add_runtime_dependency 'maven-tools', '~> 1.2.3'
   s.add_runtime_dependency 'ruby-maven', '~> 3.3', '>= 3.3.8'
-  s.add_runtime_dependency 'bundler', '> 1.5', '< 3'
+  s.add_runtime_dependency 'bundler', '> 1.5', '< 5'
   s.add_runtime_dependency 'jar-dependencies', '~> 0.3'
 
   s.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
Required for Warbler; which still has jbundler support.